### PR TITLE
[FIX] ssi_voucher_mixin: Add ondelete=cascade on journal_id

### DIFF
--- a/ssi_voucher_mixin/__manifest__.py
+++ b/ssi_voucher_mixin/__manifest__.py
@@ -4,7 +4,7 @@
 # pylint: disable=locally-disabled, manifest-required-author
 {
     "name": "Account Voucher Mixin",
-    "version": "14.0.2.3.0",
+    "version": "14.0.2.4.0",
     "category": "Accounting",
     "website": "https://simetri-sinergi.id",
     "author": "OpenSynergy Indonesia, PT. Simetri Sinergi Indonesia",

--- a/ssi_voucher_mixin/models/voucher_type_allowed_journal.py
+++ b/ssi_voucher_mixin/models/voucher_type_allowed_journal.py
@@ -19,6 +19,7 @@ class VoucherTypeAllowedJournal(models.Model):
         string="Journal",
         comodel_name="account.journal",
         required=True,
+        ondelete="cascade",
     )
     python_code = fields.Text(
         string="Domain Expression",


### PR DESCRIPTION
## Summary

Fix FK constraint violation when `l10n_generic_coa` installs and deletes all `account.journal` records.

## Root Cause

When `account` module is installed with a US company (default in test DB), `_auto_install_l10n()` queues `l10n_us` + `l10n_generic_coa`. The `l10n_generic_coa._load()` method deletes ALL `account.journal` records for the company. The FK on `account_voucher_type_allowed_journal.journal_id` has no `ON DELETE CASCADE`, causing:

```
psycopg2.IntegrityError: update or delete on table "account_journal" violates
foreign key constraint "account_voucher_type_allowed_journal_journal_id_fkey"
```

## Fix

Add `ondelete='cascade'` to `VoucherTypeAllowedJournal.journal_id`.

Contributors: Andhitia Rama <andhitia.r@gmail.com>